### PR TITLE
Invenio-cli 0.18.0 compatibility and imports fix

### DIFF
--- a/invenio_rdm_pure/cli.py
+++ b/invenio_rdm_pure/cli.py
@@ -27,9 +27,9 @@ Options:
 """
 from docopt import docopt
 
-from invenio_rdm_pure.setup import dirpath
-from invenio_rdm_pure.shell_interface import ShellInterface, method_call
-from invenio_rdm_pure.source.general_functions_source import check_if_directory_exists
+from .setup import dirpath
+from .shell_interface import ShellInterface, method_call
+from .source.general_functions_source import check_if_directory_exists
 
 if __name__ == "__main__":
     arguments = docopt(__doc__, version="Pure synchronizer 1.0")

--- a/invenio_rdm_pure/ext.py
+++ b/invenio_rdm_pure/ext.py
@@ -30,7 +30,8 @@ class InvenioRdmPure(object):
         # Use theme's base template if theme is installed
         if "BASE_TEMPLATE" in app.config:
             app.config.setdefault(
-                "INVENIO_RDM_PURE_BASE_TEMPLATE", app.config["BASE_TEMPLATE"],
+                "INVENIO_RDM_PURE_BASE_TEMPLATE",
+                app.config["BASE_TEMPLATE"],
             )
         for k in dir(config):
             if (

--- a/invenio_rdm_pure/pages.py
+++ b/invenio_rdm_pure/pages.py
@@ -9,10 +9,10 @@
 
 import json
 
-from invenio_rdm_pure.source.general_functions_source import initialize_counters
-from invenio_rdm_pure.source.pure.requests_pure import get_pure_metadata
-from invenio_rdm_pure.source.rdm.add_record import RdmAddRecord
-from invenio_rdm_pure.source.reports import Reports
+from .source.general_functions_source import initialize_counters
+from .source.pure.requests_pure import get_pure_metadata
+from .source.rdm.add_record import RdmAddRecord
+from .source.reports import Reports
 
 
 class RunPages:

--- a/invenio_rdm_pure/shell_interface.py
+++ b/invenio_rdm_pure/shell_interface.py
@@ -7,15 +7,15 @@
 
 """File description."""
 
-from invenio_rdm_pure.source.log_manager import delete_old_log_files
-from invenio_rdm_pure.source.pure.import_records import ImportRecords
-from invenio_rdm_pure.source.rdm.delete_record import Delete
-from invenio_rdm_pure.source.rdm.run.changes import PureChanges
-from invenio_rdm_pure.source.rdm.run.groups import RdmGroups
-from invenio_rdm_pure.source.rdm.run.owners import RdmOwners
-from invenio_rdm_pure.source.rdm.run.pages import RunPages
-from invenio_rdm_pure.source.rdm.run.uuid_run import AddFromUuidList
-from invenio_rdm_pure.source.rdm.testing.run_test import Testing
+from .source.log_manager import delete_old_log_files
+from .source.pure.import_records import ImportRecords
+from .source.rdm.delete_record import Delete
+from .source.rdm.run.changes import PureChanges
+from .source.rdm.run.groups import RdmGroups
+from .source.rdm.run.owners import RdmOwners
+from .source.rdm.run.pages import RunPages
+from .source.rdm.run.uuid_run import AddFromUuidList
+from .source.rdm.testing.run_test import Testing
 
 
 class ShellInterface:

--- a/invenio_rdm_pure/source/general_functions_source.py
+++ b/invenio_rdm_pure/source/general_functions_source.py
@@ -26,9 +26,18 @@ def add_spaces(value: str, max_length=5):
 def initialize_counters():
     """Initialize variables that will count through the whole task the success of each process."""
     global_counters = {
-        "metadata": {"success": 0, "error": 0,},
-        "file": {"success": 0, "error": 0,},
-        "delete": {"success": 0, "error": 0,},
+        "metadata": {
+            "success": 0,
+            "error": 0,
+        },
+        "file": {
+            "success": 0,
+            "error": 0,
+        },
+        "delete": {
+            "success": 0,
+            "error": 0,
+        },
         "total": 0,
         "http_responses": {},
     }

--- a/invenio_rdm_pure/source/log_manager.py
+++ b/invenio_rdm_pure/source/log_manager.py
@@ -10,11 +10,11 @@
 import os
 from datetime import date, datetime, timedelta
 
-from invenio_rdm_pure.source.general_functions_source import (
+from .general_functions_source import (
     check_if_file_exists,
     current_time,
 )
-from invenio_rdm_pure.source.reports import Reports
+from .reports import Reports
 
 from ..setup import (
     data_files_name,

--- a/invenio_rdm_pure/source/log_manager.py
+++ b/invenio_rdm_pure/source/log_manager.py
@@ -10,12 +10,6 @@
 import os
 from datetime import date, datetime, timedelta
 
-from .general_functions_source import (
-    check_if_file_exists,
-    current_time,
-)
-from .reports import Reports
-
 from ..setup import (
     data_files_name,
     days_keep_log,

--- a/invenio_rdm_pure/source/rdm/testing/run_test.py
+++ b/invenio_rdm_pure/source/rdm/testing/run_test.py
@@ -10,9 +10,9 @@
 import json
 import os
 
-from invenio_rdm_pure.setup import dirpath
-from invenio_rdm_pure.source.rdm.requests_rdm import Requests
-from invenio_rdm_pure.source.reports import Reports
+from ....setup import dirpath
+from ..requests_rdm import Requests
+from ...reports import Reports
 
 
 class Testing:

--- a/invenio_rdm_pure/source/rdm/testing/run_test.py
+++ b/invenio_rdm_pure/source/rdm/testing/run_test.py
@@ -11,8 +11,8 @@ import json
 import os
 
 from ....setup import dirpath
-from ..requests_rdm import Requests
 from ...reports import Reports
+from ..requests_rdm import Requests
 
 
 class Testing:

--- a/invenio_rdm_pure/views.py
+++ b/invenio_rdm_pure/views.py
@@ -16,7 +16,10 @@ from .setup import database_uri, dirpath, pure_import_file
 from .source.rdm.user_externalid import user_externalid
 
 blueprint = Blueprint(
-    "invenio_rdm_pure", __name__, template_folder="templates", static_folder="static",
+    "invenio_rdm_pure",
+    __name__,
+    template_folder="templates",
+    static_folder="static",
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ tests_require = [
 ]
 
 extras_require = {
-    "docs": ["Sphinx>=1.5.1",],
+    "docs": [
+        "Sphinx>=1.5.1",
+    ],
     "tests": tests_require,
 }
 
@@ -65,13 +67,19 @@ setup(
     include_package_data=True,
     platforms="any",
     entry_points={
-        "invenio_base.apps": ["invenio_rdm_pure = invenio_rdm_pure:InvenioRdmPure",],
+        "invenio_base.apps": [
+            "invenio_rdm_pure = invenio_rdm_pure:InvenioRdmPure",
+        ],
         "invenio_base.blueprints": [
             "invenio_rdm_pure = invenio_rdm_pure.views:blueprint",
         ],
-        "invenio_i18n.translations": ["messages = invenio_rdm_pure",],
+        "invenio_i18n.translations": [
+            "messages = invenio_rdm_pure",
+        ],
         "invenio_celery.tasks": ["invenio_rdm_pure = invenio_rdm_pure.tasks"],
-        "invenio_config.module": ["invenio_rdm_pure = invenio_rdm_pure.config",],
+        "invenio_config.module": [
+            "invenio_rdm_pure = invenio_rdm_pure.config",
+        ],
         # TODO: Edit these entry points to fit your needs.
         # 'invenio_access.actions': [],
         # 'invenio_admin.actions': [],

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires = [
     "Flask-BabelEx>=0.9.4",
     "docopt>=0.6.2",
     "invenio_oauthclient>=1.2.1",
-    "invenio-rdm-records~=0.20.8",
+    "invenio-rdm-records>=0.23.4",
     "sqlalchemy-continuum>=1.3.11",
 ]
 


### PR DESCRIPTION
The title describes the changes in this PR quite well. It includes two modifications:
1.  Modified module dependency for `invenio-rdm-records` from ´0.20.8´ to not less than ´0.23.4´. This was necessary to avoid conflicts with dependencies of ´invenio-cli 0.18.0´
2. There remained a handful of files where the module imports weren't changed to relative. They should be all relative now.